### PR TITLE
- Producing cache hints when the directive is defined on interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {
   DirectiveNode,
   getNamedType,
+  GraphQLInterfaceType,
   GraphQLObjectType,
   GraphQLResolveInfo,
   ResponsePath,
@@ -46,7 +47,8 @@ export class CacheControlExtension<TContext = any> implements GraphQLExtension<T
     let hint: CacheHint = {};
 
     const targetType = getNamedType(info.returnType);
-    if (targetType instanceof GraphQLObjectType) {
+    if (targetType instanceof GraphQLObjectType
+      || targetType instanceof GraphQLInterfaceType) {
       if (targetType.astNode) {
         hint = mergeHints(hint, cacheHintFromDirectives(targetType.astNode.directives));
       }


### PR DESCRIPTION
Currently:
When I use interfaces in my schema,
,and I have a query that returns such an interfaces, 
cache hints are never included in the response.

There are many use cases scenario when dealing with interface. This PR gives support a simple scenario that makes the implementation properly include the cache control hints in the response (when the cache control directives are declared on such interfaces interfaces)