### PR TITLE
Add defaultMaxAge option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:8
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package-lock.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm --version
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package-lock.json" }}
+
+      - run: npm run test

--- a/README.md
+++ b/README.md
@@ -98,3 +98,18 @@ You should receive cache control data in the `extensions` field of your response
   ]
 }
 ```
+
+### Setting a default maxAge
+
+The power of cache hints comes from being able to set them precisely to different values on different types and fields based on your understanding of your implementation's semantics. But when getting started with Apollo Cache Control, you might just want to apply the same `maxAge` to most of your resolvers. You can specify a default max age when you set up `cacheControl` in your server. This max age will be applied to all resolvers which don't explicitly set `maxAge` via schema hints (including schema hints on the type that they return) or the programmatic API. You can override this for a particular resolver or type by setting `@cacheControl(maxAge: 0)`. For example, for Express:
+
+```javascript
+app.use('/graphql', bodyParser.json(), graphqlExpress({
+  schema,
+  context: {},
+  tracing: true,
+  cacheControl: {
+    defaultMaxAge: 5,
+  },
+}));
+```

--- a/src/__tests__/cacheControlDirective.ts
+++ b/src/__tests__/cacheControlDirective.ts
@@ -32,6 +32,33 @@ describe('@cacheControl directives', () => {
     expect(hints).toContainEqual({ path: ['droid'], maxAge: 0 });
   });
 
+  it('should set maxAge to the default and no scope for a field without cache hints', async () => {
+    const schema = buildSchema(`
+      type Query {
+        droid(id: ID!): Droid
+      }
+
+      type Droid {
+        id: ID!
+        name: String!
+      }
+    `);
+
+    const hints = await collectCacheControlHints(
+      schema,
+      `
+        query {
+          droid(id: 2001) {
+            name
+          }
+        }
+      `,
+      { defaultMaxAge: 10 },
+    );
+
+    expect(hints).toContainEqual({ path: ['droid'], maxAge: 10 });
+  });
+
   it('should set the specified maxAge from a cache hint on the field', async () => {
     const schema = buildSchema(`
       type Query {
@@ -52,7 +79,8 @@ describe('@cacheControl directives', () => {
             name
           }
         }
-      `
+      `,
+      { defaultMaxAge: 10 },
     );
 
     expect(hints).toContainEqual({ path: ['droid'], maxAge: 60 });
@@ -78,7 +106,8 @@ describe('@cacheControl directives', () => {
             name
           }
         }
-      `
+      `,
+      { defaultMaxAge: 10 },
     );
 
     expect(hints).toContainEqual({ path: ['droid'], maxAge: 60 });
@@ -104,7 +133,8 @@ describe('@cacheControl directives', () => {
             name
           }
         }
-      `
+      `,
+      { defaultMaxAge: 10 },
     );
 
     expect(hints).toContainEqual({ path: ['droid'], maxAge: 120 });
@@ -130,7 +160,8 @@ describe('@cacheControl directives', () => {
             name
           }
         }
-      `
+      `,
+      { defaultMaxAge: 10 },
     );
 
     expect(hints).toContainEqual({ path: ['droid'], maxAge: 120, scope: CacheScope.Private });
@@ -156,7 +187,8 @@ describe('@cacheControl directives', () => {
             name
           }
         }
-      `
+      `,
+      { defaultMaxAge: 10 },
     );
 
     expect(hints).toContainEqual({ path: ['droid'], maxAge: 60, scope: CacheScope.Private });

--- a/src/__tests__/dynamicCacheControl.ts
+++ b/src/__tests__/dynamicCacheControl.ts
@@ -59,7 +59,8 @@ describe('dynamic cache control', () => {
             name
           }
         }
-      `
+      `,
+      { defaultMaxAge: 10 },
     );
 
     expect(hints).toContainEqual({ path: ['droid'], maxAge: 60 });
@@ -99,7 +100,8 @@ describe('dynamic cache control', () => {
             name
           }
         }
-      `
+      `,
+      { defaultMaxAge: 10 },
     );
 
     expect(hints).toContainEqual({ path: ['droid'], maxAge: 60, scope: CacheScope.Private });
@@ -139,7 +141,8 @@ describe('dynamic cache control', () => {
             name
           }
         }
-      `
+      `,
+      { defaultMaxAge: 10 },
     );
 
     expect(hints).toContainEqual({ path: ['droid'], maxAge: 120 });

--- a/src/__tests__/test-utils/helpers.ts
+++ b/src/__tests__/test-utils/helpers.ts
@@ -4,12 +4,12 @@ import {
 } from 'graphql';
 
 import { enableGraphQLExtensions, GraphQLExtensionStack } from 'graphql-extensions';
-import { CacheControlExtension, CacheHint } from '../..';
+import { CacheControlExtension, CacheHint, CacheControlExtensionOptions } from '../..';
 
-export async function collectCacheControlHints(schema: GraphQLSchema, source: string): Promise<CacheHint[]> {
+export async function collectCacheControlHints(schema: GraphQLSchema, source: string, options?: CacheControlExtensionOptions): Promise<CacheHint[]> {
   enableGraphQLExtensions(schema);
 
-  const cacheControlExtension = new CacheControlExtension();
+  const cacheControlExtension = new CacheControlExtension(options);
 
   const response = await graphql({
     schema,


### PR DESCRIPTION
This is an easy way to quickly say "I want everything in my schema to be cached
for 5 seconds". You can override it with specific maxAges on specific fields or
types.

An upcoming release of apollo-server-* will allow you to specify options to
cacheControl.

Also add this repo to CircleCI.