### PR TITLE
Honor overwrite default maxAge with maxAge=0 (Fixes #22)

### DIFF
--- a/src/__tests__/cacheControlDirective.ts
+++ b/src/__tests__/cacheControlDirective.ts
@@ -113,6 +113,33 @@ describe('@cacheControl directives', () => {
     expect(hints).toContainEqual({ path: ['droid'], maxAge: 60 });
   });
 
+  it('should overwrite the default maxAge when maxAge=0 is specified on the type', async () => {
+    const schema = buildSchema(`
+      type Query {
+        droid(id: ID!): Droid
+      }
+
+      type Droid @cacheControl(maxAge: 0) {
+        id: ID!
+        name: String!
+      }
+    `);
+
+    const hints = await collectCacheControlHints(
+      schema,
+      `
+        query {
+          droid(id: 2001) {
+            name
+          }
+        }
+      `,
+      { defaultMaxAge: 10 },
+    );
+
+    expect(hints).toContainEqual({ path: ['droid'], maxAge: 0 });
+  });
+
   it('should override the maxAge from the target type with that specified on a field', async () => {
     const schema = buildSchema(`
       type Query {

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ function mergeHints(hint: CacheHint, otherHint: CacheHint | undefined): CacheHin
   if (!otherHint) return hint;
 
   return {
-    maxAge: otherHint.maxAge || hint.maxAge,
+    maxAge: otherHint.maxAge !== undefined ? otherHint.maxAge : hint.maxAge,
     scope: otherHint.scope || hint.scope
   };
 }


### PR DESCRIPTION
Fixes #22 :tada: 

I only added a unit test for the case where the `maxAge` is specified on the type, since I felt it wouldn't add a lot of value to cover all of the other ways of adding the directive. Please let me know if I have to cover other cases as well.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->