### PR TITLE
Allow default caching to apply to interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,8 @@ export class CacheControlExtension<TContext = any> implements GraphQLExtension<T
     // If this field is a field on an object, look for hints on the field
     // itself, taking precedence over previously calculated hints.
     const parentType = info.parentType;
-    if (parentType instanceof GraphQLObjectType) {
+    if (parentType instanceof GraphQLObjectType
+      || parentType instanceof GraphQLInterfaceType) {
       const fieldDef = parentType.getFields()[info.fieldName];
       if (fieldDef.astNode) {
         hint = mergeHints(hint, cacheHintFromDirectives(fieldDef.astNode.directives));
@@ -79,7 +80,8 @@ export class CacheControlExtension<TContext = any> implements GraphQLExtension<T
     // hint, set the maxAge to 0 (uncached) or the default if specified in the
     // constructor.  (Non-object fields by default are assumed to inherit their
     // cacheability from their parents.)
-    if (targetType instanceof GraphQLObjectType && hint.maxAge === undefined) {
+    if ((targetType instanceof GraphQLObjectType || targetType instanceof GraphQLInterfaceType)
+      && hint.maxAge === undefined) {
       hint.maxAge = this.defaultMaxAge;
     }
 


### PR DESCRIPTION
Currently when pulling from a `node(id: ID!): Node` endpoint where the `id` is the only thing on the `Node` interface and fragments are used to specify all the fields of the expected type, nothing was being cached by default because the default caching wasn't applying to the interface.  The cache duration on `id` can be a maximum value for the system; much larger than what the default would be.

When I added the cache directive to just the `id: ID!` field, as that is not going to change, it still wouldn't cache.

Adding the cache control directive to the interface does work due to #10, but it's ~unclear if~ that will affect the minimum cache length of types that implement `Node` ~and don't specify an override of the default~.

This should take care of both of those.

This is a continuation of #10.